### PR TITLE
Update wp-show-posts.php

### DIFF
--- a/wp-show-posts.php
+++ b/wp-show-posts.php
@@ -470,7 +470,7 @@ function wpsp_display( $id, $custom_settings = false ) {
 						</div><!-- .entry-summary -->
 					<?php elseif ( ( 'full' == $settings[ 'content_type' ] || $more_tag ) && 'none' !== $settings[ 'content_type' ] ) : ?>
 						<div class="wp-show-posts-entry-content" itemprop="text">
-							<?php the_content( false, false ); ?>
+							<?php the_content( ); ?>
 						</div><!-- .entry-content -->
 					<?php endif;
 

--- a/wp-show-posts.php
+++ b/wp-show-posts.php
@@ -470,7 +470,10 @@ function wpsp_display( $id, $custom_settings = false ) {
 						</div><!-- .entry-summary -->
 					<?php elseif ( ( 'full' == $settings[ 'content_type' ] || $more_tag ) && 'none' !== $settings[ 'content_type' ] ) : ?>
 						<div class="wp-show-posts-entry-content" itemprop="text">
-							<?php the_content( ); ?>
+							<?php
+			                                    $content_more_link = apply_filters('wpsp_content_more_link', false, $settings );
+			                                    the_content( $content_more_link );
+							?>
 						</div><!-- .entry-content -->
 					<?php endif;
 


### PR DESCRIPTION
Fix the call to the_content (the first argument was incorrect). The default values will be used (null for the first argument and false for the second argument). With this change the more link will be generated. Not sure about what happens with the "read more" link text specified in the Column settings (if any). I verified that the change fixes the printing of the more link and now the "the_content_more_link" filter also works.